### PR TITLE
Use Zip instead of GZip

### DIFF
--- a/src/Codec/SelfExtract.hs
+++ b/src/Codec/SelfExtract.hs
@@ -115,7 +115,7 @@ bundle' exe dir = do
       (fromAbsFile exeWithSize)
 
     let archive = tempDir </> [relfile|bundle.tar.gz|]
-    create GZip (fromAbsFile archive) $ toFilePath dir
+    create Zip (fromAbsFile archive) $ toFilePath dir
 
     let combined = tempDir </> [relfile|exe_and_bundle|]
     cat [exeWithSize, archive] combined


### PR DESCRIPTION
The tar library has a restriction on filepath length (https://github.com/haskell/tar/issues/31). For now, use `zip` instead